### PR TITLE
typography pretendard 폰트가 적용되지 않는 오류를 수정했습니다.

### DIFF
--- a/src/components/Typography/Typography.constants.ts
+++ b/src/components/Typography/Typography.constants.ts
@@ -1,25 +1,21 @@
 export const CustomTypographyVariants = {
   // h1
   'typography/headline/h1/black': {
-    fontFamily: 'Pretendard',
     fontSize: '40px',
     fontWeight: 800,
     lineHeight: '56px',
   },
   'typography/headline/h1/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '40px',
     fontWeight: 700,
     lineHeight: '56px',
   },
   'typography/headline/h1/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '40px',
     fontWeight: 600,
     lineHeight: '56px',
   },
   'typography/headline/h1/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '40px',
     fontWeight: 400,
     lineHeight: '56px',
@@ -27,25 +23,21 @@ export const CustomTypographyVariants = {
 
   // h2
   'typography/headline/h2/black': {
-    fontFamily: 'Pretendard',
     fontSize: '36px',
     fontWeight: 800,
     lineHeight: '48px',
   },
   'typography/headline/h2/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '36px',
     fontWeight: 700,
     lineHeight: '48px',
   },
   'typography/headline/h2/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '36px',
     fontWeight: 600,
     lineHeight: '48px',
   },
   'typography/headline/h2/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '36px',
     fontWeight: 400,
     lineHeight: '48px',
@@ -53,25 +45,21 @@ export const CustomTypographyVariants = {
 
   // h3
   'typography/headline/h3/black': {
-    fontFamily: 'Pretendard',
     fontSize: '32px',
     fontWeight: 800,
     lineHeight: '42px',
   },
   'typography/headline/h3/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '32px',
     fontWeight: 700,
     lineHeight: '42px',
   },
   'typography/headline/h3/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '32px',
     fontWeight: 600,
     lineHeight: '42px',
   },
   'typography/headline/h3/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '32px',
     fontWeight: 400,
     lineHeight: '42px',
@@ -79,25 +67,21 @@ export const CustomTypographyVariants = {
 
   // h4
   'typography/headline/h4/black': {
-    fontFamily: 'Pretendard',
     fontSize: '30px',
     fontWeight: 800,
     lineHeight: '40px',
   },
   'typography/headline/h4/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '30px',
     fontWeight: 700,
     lineHeight: '40px',
   },
   'typography/headline/h4/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '30px',
     fontWeight: 600,
     lineHeight: '40px',
   },
   'typography/headline/h4/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '30px',
     fontWeight: 400,
     lineHeight: '40px',
@@ -105,25 +89,21 @@ export const CustomTypographyVariants = {
 
   // title large
   'typography/title/large/black': {
-    fontFamily: 'Pretendard',
     fontSize: '28px',
     fontWeight: 900,
     lineHeight: '36px',
   },
   'typography/title/large/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '28px',
     fontWeight: 700,
     lineHeight: '36px',
   },
   'typography/title/large/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '28px',
     fontWeight: 400,
     lineHeight: '36px',
   },
   'typography/title/large/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '28px',
     fontWeight: 400,
     lineHeight: '36px',
@@ -131,25 +111,21 @@ export const CustomTypographyVariants = {
 
   // title medium
   'typography/title/medium/black': {
-    fontFamily: 'Pretendard',
     fontSize: '24px',
     fontWeight: 800,
     lineHeight: '32px',
   },
   'typography/title/medium/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '24px',
     fontWeight: 700,
     lineHeight: '32px',
   },
   'typography/title/medium/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '24px',
     fontWeight: 600,
     lineHeight: '32px',
   },
   'typography/title/medium/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '24px',
     fontWeight: 400,
     lineHeight: '32px',
@@ -157,25 +133,21 @@ export const CustomTypographyVariants = {
 
   // title small
   'typography/title/small/black': {
-    fontFamily: 'Pretendard',
     fontSize: '20px',
     fontWeight: 900,
     lineHeight: '28px',
   },
   'typography/title/small/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '20px',
     fontWeight: 700,
     lineHeight: '28px',
   },
   'typography/title/small/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '20px',
     fontWeight: 600,
     lineHeight: '28px',
   },
   'typography/title/small/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '20px',
     fontWeight: 400,
     lineHeight: '28px',
@@ -183,25 +155,21 @@ export const CustomTypographyVariants = {
 
   // body medium
   'typography/body/medium/black': {
-    fontFamily: 'Pretendard',
     fontSize: '16px',
     fontWeight: 800,
     lineHeight: '24px',
   },
   'typography/body/medium/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '16px',
     fontWeight: 700,
     lineHeight: '24px',
   },
   'typography/body/medium/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '16px',
     fontWeight: 600,
     lineHeight: '24px',
   },
   'typography/body/medium/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '16px',
     fontWeight: 400,
     lineHeight: '24px',
@@ -209,25 +177,21 @@ export const CustomTypographyVariants = {
 
   // body small
   'typography/body/small/black': {
-    fontFamily: 'Pretendard',
     fontSize: '14px',
     fontWeight: 800,
     lineHeight: '20px',
   },
   'typography/body/small/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '14px',
     fontWeight: 700,
     lineHeight: '20px',
   },
   'typography/body/small/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '14px',
     fontWeight: 600,
     lineHeight: '20px',
   },
   'typography/body/small/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '14px',
     fontWeight: 400,
     lineHeight: '20px',
@@ -235,25 +199,21 @@ export const CustomTypographyVariants = {
 
   // label Large
   'typography/label/large/black': {
-    fontFamily: 'Pretendard',
     fontSize: '12px',
     fontWeight: 800,
     lineHeight: '16px',
   },
   'typography/label/large/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '12px',
     fontWeight: 700,
     lineHeight: '16px',
   },
   'typography/label/large/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '12px',
     fontWeight: 600,
     lineHeight: '16px',
   },
   'typography/label/large/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '12px',
     fontWeight: 400,
     lineHeight: '16px',
@@ -261,25 +221,21 @@ export const CustomTypographyVariants = {
 
   // label Medium
   'typography/label/medium/black': {
-    fontFamily: 'Pretendard',
     fontSize: '11px',
     fontWeight: 800,
     lineHeight: '14px',
   },
   'typography/label/medium/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '11px',
     fontWeight: 700,
     lineHeight: '14px',
   },
   'typography/label/medium/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '11px',
     fontWeight: 600,
     lineHeight: '14px',
   },
   'typography/label/medium/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '11px',
     fontWeight: 400,
     lineHeight: '14px',
@@ -287,25 +243,21 @@ export const CustomTypographyVariants = {
 
   // label Small
   'typography/label/small/black': {
-    fontFamily: 'Pretendard',
     fontSize: '10px',
     fontWeight: 800,
     lineHeight: '14px',
   },
   'typography/label/small/bold': {
-    fontFamily: 'Pretendard',
     fontSize: '10px',
     fontWeight: 700,
     lineHeight: '14px',
   },
   'typography/label/small/medium': {
-    fontFamily: 'Pretendard',
     fontSize: '10px',
     fontWeight: 600,
     lineHeight: '14px',
   },
   'typography/label/small/regular': {
-    fontFamily: 'Pretendard',
     fontSize: '10px',
     fontWeight: 400,
     lineHeight: '14px',

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -4,7 +4,7 @@ import { TypographyProps } from '@components/Typography/Typography.types.ts';
 
 const Typography = ({ variant, color = 'color/gray/800', children }: TypographyProps) => {
   return (
-    <MUITypography variant={variant} color={color} sx={{ fontFamily: '"Pretendard Variable", Pretendard' }}>
+    <MUITypography variant={variant} color={color}>
       {children}
     </MUITypography>
   );

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -4,7 +4,7 @@ import { TypographyProps } from '@components/Typography/Typography.types.ts';
 
 const Typography = ({ variant, color = 'color/gray/800', children }: TypographyProps) => {
   return (
-    <MUITypography variant={variant} color={color}>
+    <MUITypography variant={variant} color={color} sx={{ fontFamily: '"Pretendard Variable", Pretendard' }}>
       {children}
     </MUITypography>
   );

--- a/src/shared/settings/ThemeMui.tsx
+++ b/src/shared/settings/ThemeMui.tsx
@@ -3,6 +3,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { colorPalette } from './Color.ts';
 import { CustomTypographyVariants } from '@components/Typography/Typography.constants.ts';
 import { fontFace } from '@shared/styles/fontFaceStyle';
+import { CssBaseline } from '@mui/material';
 
 // ----------------------------------------------------------------------
 
@@ -27,8 +28,16 @@ export default function ThemeMui({ children }: Props) {
     },
     typography: {
       ...CustomTypographyVariants,
+      allVariants: {
+        fontFamily: '"Pretendard Variable", Pretendard',
+      },
     },
   });
 
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
 }

--- a/src/shared/settings/ThemeMui.tsx
+++ b/src/shared/settings/ThemeMui.tsx
@@ -24,28 +24,9 @@ export default function ThemeMui({ children }: Props) {
           noSsr: true,
         },
       },
-      MuiRadio: {
-        styleOverrides: {
-          root: {
-            padding: 0,
-            marginRight: '10px',
-            '& .MuiSvgIcon-root': {
-              height: 1,
-              width: 1,
-            },
-          },
-        },
-      },
     },
-    typography: CustomTypographyVariants,
-    breakpoints: {
-      values: {
-        xs: 0,
-        sm: 600,
-        md: 900,
-        lg: 1200,
-        xl: 1296,
-      },
+    typography: {
+      ...CustomTypographyVariants,
     },
   });
 


### PR DESCRIPTION
- MuiCssBaseLine 속성을 사용하려면, themeProvider 하위에 CssBaseLine 컴포넌트가 들어가야 해서 ThemeMui에 추가하였습니다.
- 추가로 ThemeMui에서 사용하지 않는 속성을 제거하였습니다.
- typography variants에 모두 들어가있던 font-family를 빼고 global에 적용했습니다,