### PR TITLE
left 툴팁에서 해상도가 줄어들 시 반대로 노출되는 문제 수정

### DIFF
--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -49,7 +49,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 - direction: mui의 placement와 동일하며, 디자인 시스템 피그마에 있는 툴팁의 Prop과 값이 일치합니다. direction이 "none"일 경우 arrow 아이콘이 사라집니다.
 - color: 툴팁의 배경색을 지정합니다. 기본적으로 default 값이 적용됩니다.
 
-<Canvas of={TooltipStories.Default} />
+<Canvas of={TooltipStories.Default} layout={'centered'} />
 
 <Controls
   include={[
@@ -65,7 +65,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Top
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={DefaultTopLeftTooltip} />
   <Story of={DefaultTopTooltip} />
   <Story of={DefaultTopRightTooltip} />
@@ -73,7 +73,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Left
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={DefaultLeftTopTooltip} />
   <Story of={DefaultLeftTooltip} />
   <Story of={DefaultLeftBottomTooltip} />
@@ -81,7 +81,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Bottom
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={DefaultBottomLeftTooltip} />
   <Story of={DefaultBottomTooltip} />
   <Story of={DefaultBottomRightTooltip} />
@@ -89,7 +89,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Right
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={DefaultRightTopTooltip} />
   <Story of={DefaultRightTooltip} />
   <Story of={DefaultRightBottomTooltip} />
@@ -101,7 +101,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Top
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={GrayishVioletTopLeftTooltip} />
   <Story of={GrayishVioletTopTooltip} />
   <Story of={GrayishVioletTopRightTooltip} />
@@ -109,7 +109,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Left
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={GrayishVioletLeftTopTooltip} />
   <Story of={GrayishVioletLeftTooltip} />
   <Story of={GrayishVioletLeftBottomTooltip} />
@@ -117,7 +117,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Bottom
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={GrayishVioletBottomLeftTooltip} />
   <Story of={GrayishVioletBottomTooltip} />
   <Story of={GrayishVioletBottomRightTooltip} />
@@ -125,7 +125,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Right
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={GrayishVioletRightTopTooltip} />
   <Story of={GrayishVioletRightTooltip} />
   <Story of={GrayishVioletRightBottomTooltip} />
@@ -137,7 +137,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Top
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={PrimaryTopLeftTooltip} />
   <Story of={PrimaryTopTooltip} />
   <Story of={PrimaryTopRightTooltip} />
@@ -145,7 +145,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Left
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={PrimaryLeftTopTooltip} />
   <Story of={PrimaryLeftTooltip} />
   <Story of={PrimaryLeftBottomTooltip} />
@@ -153,7 +153,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Bottom
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={PrimaryBottomLeftTooltip} />
   <Story of={PrimaryBottomTooltip} />
   <Story of={PrimaryBottomRightTooltip} />
@@ -161,7 +161,7 @@ MUI의 툴팁을 토대로 스타일을 override하여 제작되었습니다.
 
 ### Right
 
-<Canvas>
+<Canvas layout={'centered'}>
   <Story of={PrimaryRightTopTooltip} />
   <Story of={PrimaryRightTooltip} />
   <Story of={PrimaryRightBottomTooltip} />


### PR DESCRIPTION
# Issue ticket ID
PRDT-2158

# Description

## 요약
direction이 left로 설정된 툴팁이 해상도가 조금 작아지면 스토리북에서 반대 방향으로 표시되는 문제가 있었습니다.
story를 감싸는 canvas를 중앙 정렬하여 720px 이상의 해상도까지는 설정한 방향대로 표시되도록 수정하였습니다.

before
![image](https://github.com/carpenstreet/carpenstreet-design-system/assets/88374916/5bf2e3a7-8175-4265-b676-b115a77860b0)

after
![image](https://github.com/carpenstreet/carpenstreet-design-system/assets/88374916/a8e15656-4240-4736-895c-ee57b3926a9e)

# Reference
[관련 쓰레드](https://acontainer.slack.com/archives/C06NL5411UY/p1711007505082879?thread_ts=1711004316.114349&cid=C06NL5411UY)
