### PR TITLE
Typography 추가 작업

### DIFF
--- a/src/components/Typography/Typography.mdx
+++ b/src/components/Typography/Typography.mdx
@@ -6,7 +6,9 @@ import * as TypographyStories from './Typography.stories';
 
 # Typography
 
-ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 사용 목적에 따라 적절히 조합하여 사용합니다.
+ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 사용 목적에 따라 적절히 조합하여 사용합니다. <br />
+variant 옵션은 필수 값이며, color 옵션은 기본 값으로 color/gray/800이 지정되어 있습니다. <br />
+아래 표시된 옵션 이외에도 MUI의 기본 Typography 옵션을 사용 가능하며 sx 옵션으로 스타일을 커스텀하여 사용 가능합니다.
 
 <Canvas of={TypographyStories.Default} />
 
@@ -15,7 +17,8 @@ ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 
 ## Responsive
 지정된 breakpoint에 따라 variant를 지정할 수 있습니다. 아래는 예제입니다. <br />
 `desktop` breakpoint에 `typography/headline/h1/black` variant가 지정되어 있고 <br />
-`mobile` breakpoint에 `typography/title/small/black` variant가 지정되어 있습니다.
+`mobile` breakpoint에 `typography/title/small/black` variant가 지정되어 있습니다. <br />
+브라우저 사이즈를 변경하여 확인이 가능합니다.
 
 <Canvas of={TypographyStories.Responsive} />
 

--- a/src/components/Typography/Typography.mdx
+++ b/src/components/Typography/Typography.mdx
@@ -6,8 +6,10 @@ import * as TypographyStories from './Typography.stories';
 
 # Typography
 
-ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 사용 목적에 따라 적절히 조합하여 사용합니다. <br />
-variant 옵션은 필수 값이며, color 옵션은 기본 값으로 color/gray/800이 지정되어 있습니다. <br />
+ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 사용 목적에 따라 적절히 조합하여 사용합니다.
+
+variant 옵션은 필수 값이며, color 옵션은 기본 값으로 color/gray/800이 지정되어 있습니다.
+
 아래 표시된 옵션 이외에도 MUI의 기본 Typography 옵션을 사용 가능하며 sx 옵션으로 스타일을 커스텀하여 사용 가능합니다.
 
 <Canvas of={TypographyStories.Default} />
@@ -15,9 +17,12 @@ variant 옵션은 필수 값이며, color 옵션은 기본 값으로 color/gray/
 <Controls include={['variant', 'color', 'children', 'sx']} />
 
 ## Responsive
-지정된 breakpoint에 따라 variant를 지정할 수 있습니다. 아래는 예제입니다. <br />
-`desktop` breakpoint에 `typography/headline/h1/black` variant가 지정되어 있고 <br />
-`mobile` breakpoint에 `typography/title/small/black` variant가 지정되어 있습니다. <br />
+지정된 breakpoint에 따라 variant를 지정할 수 있습니다. 아래는 예제입니다.
+
+`desktop` breakpoint에 `typography/headline/h1/black` variant가 지정되어 있고
+
+`mobile` breakpoint에 `typography/title/small/black` variant가 지정되어 있습니다.
+
 브라우저 사이즈를 변경하여 확인이 가능합니다.
 
 <Canvas of={TypographyStories.Responsive} />

--- a/src/components/Typography/Typography.mdx
+++ b/src/components/Typography/Typography.mdx
@@ -10,7 +10,14 @@ ACON3D 서비스에 사용되는 타이포그래피입니다. Size와 Weight를 
 
 <Canvas of={TypographyStories.Default} />
 
-<Controls />
+<Controls include={['variant', 'color', 'children', 'sx']} />
+
+## Responsive
+지정된 breakpoint에 따라 variant를 지정할 수 있습니다. 아래는 예제입니다. <br />
+`desktop` breakpoint에 `typography/headline/h1/black` variant가 지정되어 있고 <br />
+`mobile` breakpoint에 `typography/title/small/black` variant가 지정되어 있습니다.
+
+<Canvas of={TypographyStories.Responsive} />
 
 ## Variants
 

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -24,6 +24,19 @@ export const Default: Story = {
   },
 };
 
+export const Responsive: Story = {
+  args: {
+    variant: 'typography/headline/h1/black',
+    children: '내 인생의 전환점은 타이포그래피 수업이었다.',
+    sx: {
+      typography: {
+        desktop: 'typography/headline/h1/black',
+        mobile: 'typography/title/small/black',
+      },
+    },
+  },
+};
+
 export const HeadlineH1Black: Story = {
   args: {
     variant: 'typography/headline/h1/black',

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -21,6 +21,7 @@ export const Default: Story = {
   args: {
     variant: 'typography/headline/h1/regular',
     children: '내 인생의 전환점은 타이포그래피 수업이었다.',
+    sx: {},
   },
 };
 

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Typography as MUITypography } from '@mui/material';
 import { TypographyProps } from './Typography.types.ts';
 
-export default function Typography({ variant, color = 'color/gray/800', children }: TypographyProps) {
+export default function Typography({ color = 'color/gray/800', children, ...rest }: TypographyProps) {
   return (
-    <MUITypography variant={variant} color={color}>
+    <MUITypography color={color} {...rest}>
       {children}
     </MUITypography>
   );


### PR DESCRIPTION
# Issue ticket ID
PRDT-2230

# CheckList

***Reviewr는 아래 체크리스트를 확인해주세요***

(PR 작성자는 체크리스트를 수정하지 마세요)

- [x] `ooo.stories.ts` 파일에 `title`이 제대로 설정되어 있는가?
- [x] `ooo.tsx` 파일이 `export default function`을 사용하고 있는가?
- [x] `ooo.types.ts` 파일에서 MUI type을 적당한 곳에서 잘 import해오고 있는가?
- [x] `ooo.mdx` 파일에서 `<Controls />`의 `include` prop이 잘 설정되어 있는가?
- [x] 변경사항 전반적으로 import문을 `index.ts`가 아닌 정확한 파일에서 import하고 있는가?

# Description

## 요약
- Typography에 mui의 다른 Props들도 받을 수 있도록 타입이 설정되어 있지만, 실제 컴포넌트에서는 color, variant 외 다른 prop들은 적용되지 않고 있었습니다. 이를 모두 넘겨줄 수 있도록 수정하였습니다.
- 추후 breakpoint 별 variant 설정이 필요할 것이라 생각되었고 이와 관련된 가이드 문서를 추가로 보충하였습니다.
- mdx의 Controls 태그에 include를 추가하여 모든 MUI의 typography 속성이 표시되는게 아닌 많이 사용되는  Props들만 표시되도록 수정하였습니다.