### PR TITLE
Menu, MenuItem 컴포넌트 구현

### DIFF
--- a/src/components/Menu/ExampleMenu.tsx
+++ b/src/components/Menu/ExampleMenu.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Menu from './Menu.tsx';
+import MenuItem from '../MenuItem/MenuItem.tsx';
+import { Box } from '@mui/material';
+import Button from '../Button/Button.tsx';
+import { MenuPropsType } from './Menu.types.ts';
+
+export default function ExampleMenu({ ...rest }: MenuPropsType) {
+  const [selectedIndex, setSelectedIndex] = React.useState(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => setAnchorEl(event.currentTarget);
+
+  const handleClose = () => setAnchorEl(null);
+
+  const handleMenuItemClick = (index: number) => () => {
+    setSelectedIndex(index);
+    handleClose();
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: '10px', width: '250px', marginBottom: '100px' }}>
+      <Button color={'primary'} variant={'contained'} size={'M'} sx={{ width: '100%' }} onClick={handleClick}>
+        Click
+      </Button>
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose} {...rest}>
+        {new Array(10).fill(null).map((_, idx) => (
+          <MenuItem key={idx} selected={selectedIndex === idx} onClick={handleMenuItemClick(idx)}>
+            Menu Item Menu Item!
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}

--- a/src/components/Menu/Menu.mdx
+++ b/src/components/Menu/Menu.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Controls, Meta, Story } from '@storybook/blocks';
+import * as MenuStories from './Menu.stories';
+
+<Meta of={MenuStories} />
+
+# Menu
+버튼 또는 텍스트 등 특정 요소의 상호작용을 통해 표시됩니다. 자세한 사용 방법은 [Mui의 Menu 컴포넌트 문서](https://mui.com/material-ui/react-menu/)를 참고하세요.
+
+Mui의 Menu 기본 Prop과 함께 추가로 width, fullWidth, paperSx 옵션이 주어집니다.
+
+- width 옵션은 number 타입이며, Menu의 고정 너비를 지정합니다.
+- fullWidth는 boolean 값으로 true일 경우 상위 요소의 너비에 맞춰 Menu의 너비를 지정합니다.
+- Menu의 sx는 popover로 지정되어 있습니다. Menu Paper 요소에 스타일을 지정하려면 paperSx 옵션을 사용해주세요.
+
+<Canvas of={MenuStories.Default} />
+
+<Controls include={['width', 'fullWidth', 'sx', 'paperSx']} />
+
+---
+
+### Width Fixed with Scroll
+- 좌측 Menu 컴포넌트 너비: 300px
+- 우측 Menu 컴포넌트 너비: 100px
+
+<Canvas>
+  <Story of={MenuStories.FixedMenuWithScrollLeft} />
+  <Story of={MenuStories.FixedMenuWithScrollRight} />
+</Canvas>
+
+### Width Hug with Scroll
+Menu 컴포넌트의 너비를 Menu Item의 너비에 맞춤
+
+<Canvas of={MenuStories.HugMenuWithScroll} />
+
+### Full Width with Scroll
+Menu 컴포넌트의 너비를 상위 요소에 맞춤.
+
+<Canvas of={MenuStories.FullWidthMenu} />

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ThemeMui from '../../shared/settings/ThemeMui.tsx';
+import ExampleMenu from './ExampleMenu.tsx';
+
+const meta: Meta<typeof ExampleMenu> = {
+  title: 'Component/Menu',
+  component: ExampleMenu,
+  decorators: [
+    (Story) => (
+      <ThemeMui>
+        <Story />
+      </ThemeMui>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExampleMenu>;
+
+export const Default: Story = {
+  args: {
+    fullWidth: false,
+    width: undefined,
+    paperSx: {},
+    sx: {},
+  },
+};
+
+export const FixedMenuWithScrollLeft: Story = {
+  args: {
+    width: 300,
+  },
+};
+
+export const FixedMenuWithScrollRight: Story = {
+  args: {
+    width: 100,
+  },
+};
+
+export const HugMenuWithScroll: Story = {
+  args: {},
+};
+
+export const FullWidthMenu: Story = {
+  args: {
+    fullWidth: true,
+    paperSx: {
+      marginTop: '8px',
+    },
+  },
+};

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -45,8 +45,5 @@ export const HugMenuWithScroll: Story = {
 export const FullWidthMenu: Story = {
   args: {
     fullWidth: true,
-    paperSx: {
-      marginTop: '8px',
-    },
   },
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import MUIMenu from '@mui/material/Menu';
+import { MenuPropsType } from './Menu.types.ts';
+
+export default function Menu({ width, fullWidth, children, anchorEl, sx, paperSx, ...rest }: MenuPropsType) {
+  const menuSx = {
+    '& .MuiPaper-root': {
+      ...(width !== null && width !== undefined && { width }),
+      ...(fullWidth && { width: `${anchorEl && anchorEl instanceof Element && anchorEl.clientWidth}px` }),
+      ...paperSx,
+    },
+    ...sx,
+  };
+
+  return (
+    <MUIMenu anchorEl={anchorEl} sx={menuSx} {...rest}>
+      {children}
+    </MUIMenu>
+  );
+}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -5,7 +5,7 @@ import { MenuPropsType } from './Menu.types.ts';
 export default function Menu({ width, fullWidth, children, anchorEl, sx, paperSx, ...rest }: MenuPropsType) {
   const menuSx = {
     '& .MuiPaper-root': {
-      ...(width !== null && width !== undefined && { width }),
+      ...(width && { width }),
       ...(fullWidth && { width: `${anchorEl && anchorEl instanceof Element && anchorEl.clientWidth}px` }),
       ...paperSx,
     },

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import { MenuProps as MUIMenuProps } from '@mui/material/Menu/Menu';
+
+export type MenuPropsType = MUIMenuProps & {
+  width?: number;
+  fullWidth?: boolean;
+  paperSx?: React.CSSProperties;
+};

--- a/src/components/MenuItem/ExampleMenuItem.tsx
+++ b/src/components/MenuItem/ExampleMenuItem.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import MenuItem from './MenuItem.tsx';
+import { MenuItemProps } from './MenuItem.types.ts';
+
+export default function ExampleMenuItem({ children, ...rest }: MenuItemProps) {
+  return (
+    <Box
+      sx={{
+        borderWidth: '1px',
+        borderColor: 'color/gray/100',
+        borderStyle: 'solid',
+        borderRadius: '4px',
+        width: 'fit-content',
+      }}
+    >
+      <MenuItem {...rest}>{children}</MenuItem>
+    </Box>
+  );
+}

--- a/src/components/MenuItem/MenuItem.mdx
+++ b/src/components/MenuItem/MenuItem.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Controls, Meta, Story } from '@storybook/blocks';
+import * as MenuItemStories from './MenuItem.stories';
+
+<Meta of={MenuItemStories} />
+
+# Menu Item
+
+`default`와 `disabled` 상태의 경우 Menu Item의 배경색이 `Transparent`로 설정되기 때문에, 구분을 위해 `border: 1px color/gray/100 solid` 스타일을 적용했습니다.
+
+<Canvas of={MenuItemStories.Default} />
+
+<Controls include={['selected', 'disabled', 'children', 'sx']} />
+
+### Status
+
+<Canvas>
+  <Story of={MenuItemStories.DefaultMenuItem} />
+  <Story of={MenuItemStories.SelectedMenuItem} />
+  <Story of={MenuItemStories.DisabledMenuItem} />
+</Canvas>

--- a/src/components/MenuItem/MenuItem.stories.tsx
+++ b/src/components/MenuItem/MenuItem.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ThemeMui from '../../shared/settings/ThemeMui.tsx';
+import ExampleMenuItem from './ExampleMenuItem.tsx';
+
+const meta: Meta<typeof ExampleMenuItem> = {
+  title: 'Component/MenuItem',
+  component: ExampleMenuItem,
+  decorators: [
+    (Story) => (
+      <ThemeMui>
+        <Story />
+      </ThemeMui>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExampleMenuItem>;
+
+export const Default: Story = {
+  args: {
+    selected: false,
+    disabled: false,
+    children: 'Menu Item',
+    sx: {},
+  },
+};
+
+export const DefaultMenuItem: Story = {
+  args: {
+    selected: false,
+    disabled: false,
+    children: 'Default',
+    sx: {},
+  },
+};
+
+export const SelectedMenuItem: Story = {
+  args: {
+    selected: true,
+    disabled: false,
+    children: 'Selected',
+    sx: {},
+  },
+};
+
+export const DisabledMenuItem: Story = {
+  args: {
+    selected: false,
+    disabled: true,
+    children: 'Disabled',
+    sx: {},
+  },
+};

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import MUIMenuItem from '@mui/material/MenuItem';
+import { MenuItemProps } from './MenuItem.types.ts';
+import Typography from '../Typography/Typography.tsx';
+import { CustomTypographyVariantsTypes } from '../Typography/Typography.types.ts';
+import { CustomColorPaletteTypes } from '../../shared/settings/color/color.type.ts';
+
+export default function MenuItem({ children, selected, disabled, ...rest }: MenuItemProps) {
+  const typographyVariant: CustomTypographyVariantsTypes = (() => {
+    if (selected) return 'typography/body/small/medium';
+    return 'typography/body/small/regular';
+  })();
+
+  const typographyColor: CustomColorPaletteTypes = (() => {
+    if (disabled) return 'color/gray/200';
+    return 'color/gray/800';
+  })();
+
+  return (
+    <MUIMenuItem selected={selected} disabled={disabled} {...rest}>
+      <Typography variant={typographyVariant} color={typographyColor}>
+        {children}
+      </Typography>
+    </MUIMenuItem>
+  );
+}

--- a/src/components/MenuItem/MenuItem.types.ts
+++ b/src/components/MenuItem/MenuItem.types.ts
@@ -1,0 +1,3 @@
+import { MenuItemProps as MuiMenuItemProps } from '@mui/material/MenuItem';
+
+export type MenuItemProps = MuiMenuItemProps;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -51,6 +51,8 @@ import LabelPartnership from './LabelPartnership/LabelPartnership';
 import TextField from './Textfield/TextField';
 import Avatar from './Avatar/Avatar';
 import Tab from './Tab/Tab';
+import Menu from './Menu/Menu';
+import MenuItem from './MenuItem/MenuItem';
 
 export {
   Button,
@@ -106,6 +108,8 @@ export {
   TextField,
   Avatar,
   Tab,
+  Menu,
+  MenuItem,
 };
 
 export default {
@@ -162,4 +166,6 @@ export default {
   TextField,
   Avatar,
   Tab,
+  Menu,
+  MenuItem,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ import {
   TextField,
   Avatar,
   Tab,
+  Menu,
+  MenuItem,
 } from './components';
 
 export {
@@ -112,6 +114,8 @@ export {
   TextField,
   Avatar,
   Tab,
+  Menu,
+  MenuItem,
 };
 
 export default {
@@ -170,4 +174,6 @@ export default {
   TextField,
   Avatar,
   Tab,
+  Menu,
+  MenuItem,
 };

--- a/src/shared/settings/ThemeMui.tsx
+++ b/src/shared/settings/ThemeMui.tsx
@@ -12,6 +12,8 @@ import { overrideCheckbox } from './checkbox/checkbox.ts';
 import { overrideTooltip } from './tooltip/tooltip.ts';
 import { overrideAvatar } from './avatar/avatar.ts';
 import { overrideTab } from './tab/tab.ts';
+import { overrideMenuItem } from './menuItem/menuItem.ts';
+import { overrideMenu } from './menu/menu.ts';
 
 // ----------------------------------------------------------------------
 
@@ -53,6 +55,8 @@ export default function ThemeMui({ children }: Props) {
       MuiTooltip: overrideTooltip,
       MuiAvatar: overrideAvatar,
       MuiTab: overrideTab,
+      MuiMenuItem: overrideMenuItem,
+      MuiMenu: overrideMenu,
     },
     typography: {
       ...CustomTypographyVariants,

--- a/src/shared/settings/menu/menu.ts
+++ b/src/shared/settings/menu/menu.ts
@@ -1,0 +1,31 @@
+import { Components, Theme } from '@mui/material';
+
+export const overrideMenu = {
+  defaultProps: {
+    transitionDuration: 0,
+  },
+  styleOverrides: {
+    root: ({ theme, ownerState }) => ({
+      '& .MuiPaper-root': {
+        backgroundColor: theme.palette['color/white'],
+        boxShadow: theme.shadows[4],
+        borderRadius: '8px',
+        height: '160px',
+
+        '&::-webkit-scrollbar': {
+          width: '14px',
+        },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: '#c3c3c5',
+          border: '4px solid transparent',
+          borderRadius: '10px',
+          backgroundClip: 'padding-box',
+        },
+        '& .MuiList-root': {
+          padding: '0px',
+          width: 'unset',
+        },
+      },
+    }),
+  },
+} satisfies Components<Theme>['MuiMenu'];

--- a/src/shared/settings/menuItem/menuItem.ts
+++ b/src/shared/settings/menuItem/menuItem.ts
@@ -13,7 +13,7 @@ export const overrideMenuItem = {
       '&:hover': {
         backgroundColor: theme.palette['color/gray/dim/100'],
       },
-      '&.Mui-selected': {
+      '&.Mui-selected, &.Mui-selected:hover': {
         backgroundColor: theme.palette['color/primary/dim/100'],
       },
       '& .MuiTypography-root': {

--- a/src/shared/settings/menuItem/menuItem.ts
+++ b/src/shared/settings/menuItem/menuItem.ts
@@ -1,0 +1,26 @@
+import { Components, Theme } from '@mui/material';
+
+export const overrideMenuItem = {
+  defaultProps: {
+    disableRipple: true,
+  },
+  styleOverrides: {
+    root: ({ theme }) => ({
+      padding: '6px 16px',
+      display: 'flex',
+      minHeight: 'auto',
+
+      '&:hover': {
+        backgroundColor: theme.palette['color/gray/dim/100'],
+      },
+      '&.Mui-selected': {
+        backgroundColor: theme.palette['color/primary/dim/100'],
+      },
+      '& .MuiTypography-root': {
+        width: '100%',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+      },
+    }),
+  },
+} satisfies Components<Theme>['MuiMenuItem'];


### PR DESCRIPTION
# Issue ticket ID

_해당 PR이 연결된 이슈 티켓의 ID를 적어주세요. (ex. PRDT-1399)_  
_이슈 URL을 복사해 붙여넣어도 괜찮습니다._

PRDT-2151

# CheckList

***Reviewr는 아래 체크리스트를 확인해주세요***

(PR 작성자는 체크리스트를 수정하지 마세요)

- [x] `ooo.stories.ts` 파일에 `title`이 제대로 설정되어 있는가?
- [x] `ooo.tsx` 파일이 `export default function`을 사용하고 있는가?
- [x] `ooo.types.ts` 파일에서 MUI type을 적당한 곳에서 잘 import해오고 있는가?
- [x] `ooo.mdx` 파일에서 `<Controls />`의 `include` prop이 잘 설정되어 있는가?
- [x] 변경사항 전반적으로 import문을 `index.ts`가 아닌 정확한 파일에서 import하고 있는가?

# Description

## 요약

_이번 PR의 요약을 적어주세요. 3줄 이내 작성을 권장합니다._
- 디자인시스템 피그마의 Menu, MenuItem 컴포넌트를 구현했습니다.
- MUI의 Menu 기본 너비는 MenuItem 기준으로 잡히고, 너비를 설정하는 다른 옵션이 없어서 fullWidth와 width prop을 추가하였습니다.
- width는 고정 너비 fullWidth는 Menu의 anchor Element의 너비

# Reference

_참고문서, 참고링크 등을 적어주세요._
