### PR TITLE
Button, Modal 추가 수정사항 반영

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,35 +10,35 @@ export default function Button(props: ButtonProps) {
 
   const typoVariant = ((): CustomTypographyVariantsTypes => {
     if (variant === 'contained') {
-      if (size === 'L' || size === 'XL') return 'typography/body/medium/bold';
+      if (size === 'L') return 'typography/body/medium/bold';
       if (size === 'M') return 'typography/body/small/bold';
       if (size === 'S') return 'typography/label/large/bold';
     }
     if (variant === 'outlined') {
-      if (size === 'L' || size === 'XL') return 'typography/body/medium/bold';
+      if (size === 'L') return 'typography/body/medium/bold';
       if (size === 'M') return 'typography/body/small/bold';
       if (size === 'S') return 'typography/label/large/bold';
     }
     if (variant === 'text') {
       if (weight === 'regular') {
-        if (size === 'L' || size === 'XL') return 'typography/body/medium/regular';
+        if (size === 'L') return 'typography/body/medium/regular';
         if (size === 'M') return 'typography/body/small/regular';
         if (size === 'S') return 'typography/label/large/regular';
       }
       if (weight === 'bold') {
-        if (size === 'L' || size === 'XL') return 'typography/body/medium/bold';
+        if (size === 'L') return 'typography/body/medium/bold';
         if (size === 'M') return 'typography/body/small/bold';
         if (size === 'S') return 'typography/label/large/bold';
       }
     }
     if (variant === 'underlined') {
       if (weight === 'regular') {
-        if (size === 'L' || size === 'XL') return 'typography/body/medium/regular';
+        if (size === 'L') return 'typography/body/medium/regular';
         if (size === 'M') return 'typography/body/small/regular';
         if (size === 'S') return 'typography/label/large/regular';
       }
       if (weight === 'bold') {
-        if (size === 'L' || size === 'XL') return 'typography/body/medium/bold';
+        if (size === 'L') return 'typography/body/medium/bold';
         if (size === 'M') return 'typography/body/small/bold';
         if (size === 'S') return 'typography/label/large/bold';
       }
@@ -47,20 +47,12 @@ export default function Button(props: ButtonProps) {
 
   React.useEffect(() => {
     if (variant === 'contained') {
-      if (size === 'XL') console.error('Design system Button props error: size - contained variant는 XL을 지원하지 않습니다 (fallback 처리로 L 사이즈가 적용되었습니다)');
       if (color === 'gray') console.error('Design system Button props error: color - contained variant는 gray를 지원하지 않습니다 (fallback 처리로 default가 적용되었습니다)');
       if (weight === 'bold') console.error('Design system Button props error: weight - contained variant는  bold를 지원하지 않습니다 (regular와 동일하게 처리됩니다)');
     }
     if (variant === 'outlined') {
-      if (size === 'XL') console.error('Design system Button props error: size - outlined variant는 XL을 지원하지 않습니다 (fallback 처리로 L 사이즈가 적용되었습니다)');
       if (color === 'gray') console.error('Design system Button props error: color - outlined variant는 gray를 지원하지 않습니다 (fallback 처리로 default가 적용되었습니다)');
       if (weight === 'bold') console.error('Design system Button props error: weight - outlined variant는  bold를 지원하지 않습니다 (regular와 동일하게 처리됩니다)');
-    }
-    if (variant === 'text') {
-      if (size === 'XL') console.error('Design system Button props error: size - text variant는 XL을 지원하지 않습니다 (fallback 처리로 L 사이즈가 적용되었습니다)');
-    }
-    if (variant === 'underlined') {
-      if (size === 'XL') console.error('Design system Button props error: size - underlined variant는 XL을 지원하지 않습니다 (fallback 처리로 L 사이즈가 적용되었습니다)');
     }
   }, [variant, size, color, weight]);
 

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -4,7 +4,7 @@ import { ButtonProps as MUIButtonProps } from '@mui/material';
 export type ButtonProps = Omit<MUIButtonProps, 'children' | 'variant' | 'size' | 'color'> & {
   children: MUITypographyProps['children'];
   variant: 'contained' | 'outlined' | 'text' | 'underlined';
-  size: 'XL' | 'L' | 'M' | 'S';
+  size: 'L' | 'M' | 'S';
   color?: 'primary' | 'default' | 'gray';
   weight?: 'regular' | 'bold';
 };

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -17,10 +17,10 @@ import * as ModalStories from './Modal.stories';
 ### CSS Classes
 
 Modal 컴포넌트는 아래와 같은 Class를 제공하며, 해당 클래스들을 사용하여 커스텀 스타일을 적용할 수 있습니다.
-- `.modal-title`: 제목 영역을 감싸고 있는 영역입니다.
-- `.modal-content`: 콘텐츠 영역을 감싸고 있는 영역입니다.
-- `.modal-title-content-wrapper`: 제목과 콘텐츠 영역을 감싸고 있는 영역입니다.
-- `.modal-actions`: 액션 버튼을 감싸고 있는 영역입니다.
+- `.modal-title`: 제목 요소를 감싸고 있는 영역입니다.
+- `.modal-content`: 콘텐츠 요소를 감싸고 있는 영역입니다.
+- `.modal-title-content-wrapper`: 제목과 콘텐츠 요소를 감싸고 있는 영역입니다.
+- `.modal-actions`: 액션 버튼 요소를 감싸고 있는 영역입니다.
 
 <Canvas of={ModalStories.Default} sourceState={'hidden'} />
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -37,10 +37,10 @@ export const Default: Story = {
     renderActions: (
       <Stack gap={'8px'}>
         <Button color={'primary'} size={'L'} variant={'contained'}>
-          취소
+          확인
         </Button>
         <Button color={'default'} size={'L'} variant={'outlined'}>
-          확인
+          취소
         </Button>
       </Stack>
     ),
@@ -65,10 +65,10 @@ export const ButtonVerticalModal: Story = {
     renderActions: (
       <Stack gap={'8px'}>
         <Button color={'primary'} size={'L'} variant={'contained'}>
-          취소
+          확인
         </Button>
         <Button color={'default'} size={'L'} variant={'outlined'}>
-          확인
+          취소
         </Button>
       </Stack>
     ),
@@ -89,10 +89,10 @@ export const ButtonVerticalModalOnlyDescription: Story = {
     renderActions: (
       <Stack gap={'8px'}>
         <Button color={'primary'} size={'L'} variant={'contained'}>
-          취소
+          확인
         </Button>
         <Button color={'default'} size={'L'} variant={'outlined'}>
-          확인
+          취소
         </Button>
       </Stack>
     ),
@@ -116,10 +116,10 @@ export const ButtonHorizontalModal: Story = {
     ),
     renderActions: (
       <Stack gap={'8px'} direction={'row'}>
-        <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
+        <Button color={'default'} size={'L'} variant={'outlined'} fullWidth>
           취소
         </Button>
-        <Button color={'default'} size={'L'} variant={'outlined'} fullWidth>
+        <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
           확인
         </Button>
       </Stack>
@@ -140,10 +140,10 @@ export const ButtonHorizontalModalOnlyDescription: Story = {
     ),
     renderActions: (
       <Stack gap={'8px'} direction={'row'}>
-        <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
+        <Button color={'default'} size={'L'} variant={'outlined'} fullWidth>
           취소
         </Button>
-        <Button color={'default'} size={'L'} variant={'outlined'} fullWidth>
+        <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
           확인
         </Button>
       </Stack>
@@ -168,7 +168,7 @@ export const ButtonSingleModal: Story = {
     ),
     renderActions: (
       <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
-        취소
+        확인
       </Button>
     ),
     sx: {},
@@ -186,7 +186,7 @@ export const ButtonSingleModalOnlyDescription: Story = {
       </Typography>
     ),
     renderActions: (
-      <Button color={'default'} size={'L'} variant={'outlined'} fullWidth>
+      <Button color={'primary'} size={'L'} variant={'contained'} fullWidth>
         확인
       </Button>
     ),

--- a/src/shared/settings/button/button.ts
+++ b/src/shared/settings/button/button.ts
@@ -20,7 +20,7 @@ export const overrideButton = {
       '& > .MuiButton-endIcon': {
         marginLeft: '4px',
       },
-      ...((ownerState.size === 'XL' || ownerState.size === 'L') && {
+      ...(ownerState.size === 'L' && {
         '& > .MuiButton-icon': {
           '& > svg': {
             width: '24px',
@@ -56,8 +56,7 @@ export const overrideButton = {
       },
 
       // Size
-      // contained의 경우 XL 사이즈를 지원하지 않으므로 XL 입력받을 경우 fallback으로 L 사이즈 적용함
-      ...((ownerState.size === 'L' || ownerState.size === 'XL') && {
+      ...(ownerState.size === 'L' && {
         borderRadius: '8px',
         paddingLeft: '22px',
         paddingRight: '22px',
@@ -119,8 +118,7 @@ export const overrideButton = {
     }),
     outlined: ({ ownerState, theme }) => ({
       // Size
-      // outlined의 경우 XL 사이즈를 지원하지 않으므로 XL 입력받을 경우 fallback으로 L 사이즈 적용함
-      ...((ownerState.size === 'L' || ownerState.size === 'XL') && {
+      ...(ownerState.size === 'L' && {
         borderRadius: '8px',
         paddingLeft: '21px', // border 값만큼 빼줌 (22 - 1) box-shadow css 로도 설정할 수 있지만, hover 시에 스타일이 깨지는 문제가 있어서 보류
         paddingRight: '21px', // border 값만큼 빼줌 (22 - 1)
@@ -195,8 +193,7 @@ export const overrideButton = {
       backgroundColor: 'transparent',
 
       // Size
-      // text 버튼은 XL 사이즈를 지원하지 않음
-      ...((ownerState.size === 'XL' || ownerState.size === 'L') && {
+      ...(ownerState.size === 'L' && {
         height: '24px',
       }),
       ...(ownerState.size === 'M' && {

--- a/src/shared/settings/theme.ts
+++ b/src/shared/settings/theme.ts
@@ -111,7 +111,6 @@ declare module '@mui/material/Button' {
   }
 
   interface ButtonPropsSizeOverrides {
-    XL: true;
     L: true;
     M: true;
     S: true;


### PR DESCRIPTION
- Button의 XL 사이즈 제거
- Modal에서 확인 문구가 들어간 버튼은 primary variant로 변경

# Issue ticket ID

_해당 PR이 연결된 이슈 티켓의 ID를 적어주세요. (ex. PRDT-1399)_  
_이슈 URL을 복사해 붙여넣어도 괜찮습니다._

PRDT-2291

# CheckList

***Reviewr는 아래 체크리스트를 확인해주세요***

(PR 작성자는 체크리스트를 수정하지 마세요)

- [x] `ooo.stories.ts` 파일에 `title`이 제대로 설정되어 있는가?
- [x] `ooo.tsx` 파일이 `export default function`을 사용하고 있는가?
- [x] `ooo.types.ts` 파일에서 MUI type을 적당한 곳에서 잘 import해오고 있는가?
- [x] `ooo.mdx` 파일에서 `<Controls />`의 `include` prop이 잘 설정되어 있는가?
- [x] 변경사항 전반적으로 import문을 `index.ts`가 아닌 정확한 파일에서 import하고 있는가?
- [x] 작업된 컴포넌트를 `src/index.ts`, `src/components/index.ts` 파일에서 export하고 있는가?

# Description

## 요약

_이번 PR의 요약을 적어주세요. 3줄 이내 작성을 권장합니다._

- 엘로디님께서 추가로 수정요청을 주셨던 Modal의 Button의 variant 변경 (확인 버튼은 primary)을 적용했고 Button의 XL 사이즈를 제거했습니다.
- Button XL은 디자인 시스템 피그마에도 빠져서 버튼 타입 및 스타일에도 제거했습니다.
