### PR TITLE
menu 컴포넌트 기본 height 제거

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -21,7 +21,7 @@ export const Default: Story = {
   args: {
     fullWidth: false,
     width: undefined,
-    paperSx: {},
+    paperSx: { height: '160px' },
     sx: {},
   },
 };
@@ -29,21 +29,26 @@ export const Default: Story = {
 export const FixedMenuWithScrollLeft: Story = {
   args: {
     width: 300,
+    paperSx: { height: '160px' },
   },
 };
 
 export const FixedMenuWithScrollRight: Story = {
   args: {
     width: 100,
+    paperSx: { height: '160px' },
   },
 };
 
 export const HugMenuWithScroll: Story = {
-  args: {},
+  args: {
+    paperSx: { height: '160px' },
+  },
 };
 
 export const FullWidthMenu: Story = {
   args: {
     fullWidth: true,
+    paperSx: { height: '160px' },
   },
 };

--- a/src/shared/settings/menu/menu.ts
+++ b/src/shared/settings/menu/menu.ts
@@ -10,7 +10,6 @@ export const overrideMenu = {
         backgroundColor: theme.palette['color/white'],
         boxShadow: theme.shadows[4],
         borderRadius: '8px',
-        height: '160px',
 
         '&::-webkit-scrollbar': {
           width: '14px',


### PR DESCRIPTION
# Issue ticket ID

_해당 PR이 연결된 이슈 티켓의 ID를 적어주세요. (ex. PRDT-1399)_  
_이슈 URL을 복사해 붙여넣어도 괜찮습니다._

PRDT-2308

# Description

## 요약

_이번 PR의 요약을 적어주세요. 3줄 이내 작성을 권장합니다._

- 기존 메뉴 컴포넌트에 기본적으로 160px의 세로 길이가 적용되어 있었음.
- 하지만 메뉴 컴포넌트를 160px 고정 길이로 사용하는 경우는 거의 없고 대부분 auto로 쓰거나 사용하는 곳에서 고정 길이를 지정함.
- 사용하는 곳에서 세로길이 스타일 수정을 줄이기 위해 기본적으로 적용된 height을 제거
- 이미 사용된 메뉴 컴포넌트들에도 수정으로 인한 문제가 없는 것을 확인했습니다.

# Reference

_참고문서, 참고링크 등을 적어주세요._

[jira](https://carpenstreet.atlassian.net/browse/PRDT-2308)
